### PR TITLE
docs: add note explaining vLLM usage on Jetson Thor

### DIFF
--- a/docs/JETSON_THOR.md
+++ b/docs/JETSON_THOR.md
@@ -17,6 +17,7 @@ examples/voice_agent_webrtc/
 ├── docker-compose.jetson.yml   # Jetson-specific deployment
 └── env.jetson.example          # Template for .env.jetson
 ```
+> **Note:** This deployment uses vLLM for LLM inference instead of NVIDIA NIM. NIMs use TensorRT-LLM which provides optimized, pre-compiled inference engines for specific GPU architectures. Since Jetson Thor NIMs are not yet available, vLLM serves as a flexible alternative that can load HuggingFace models directly. Once Jetson Thor NIMs are released, they can be swapped in for improved inference performance.
 
 ## Step 1: Clone Project
 


### PR DESCRIPTION
Add clarification in JETSON_THOR.md explaining why vLLM is used instead of NVIDIA NIM for LLM inference. NIMs use TensorRT-LLM which requires architecture-specific pre-compiled engines, and Jetson Thor NIMs are not yet available.